### PR TITLE
Add default active state

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -137,6 +137,8 @@ var Helpers = {
                   this.props.onSetInactive();
                 }
                 this.setState({ active : false });
+            } else {
+                this.setState ({ active: true })
             }
           }.bind(this)
 


### PR DESCRIPTION
This solve the problem when mount and unmount in the same parent container.